### PR TITLE
Gnuplot master templating (`v3`)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,7 @@ linters-settings:
     # The maximal average package complexity.
     # If it's higher than 0.0 (float) the check is enabled
     # Default: 0.0
-    package-average: 10.0
+    package-average: 20.0
   varnamelen:
     ignore-names:
       - tt

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -21,6 +21,7 @@ func NewMigrateCommand() *cobra.Command {
 				log.Fatal().Err(err).Msg("Error getting the current working directory")
 			}
 
+			// v2
 			migrated, err := migrate.SplitDescriptionFile(path + "/")
 			if err != nil {
 				log.Fatal().Err(err).Str("filename", path).Msg("migration error")
@@ -41,6 +42,7 @@ func NewMigrateCommand() *cobra.Command {
 					Msg("Removed obsolete files from activity")
 			}
 
+			// v2
 			migrated, err = migrate.SplitImagesIncludeInOwnFile(path + "/")
 			if err != nil {
 				log.Fatal().Err(err).Str("filename", path).Msg("Migration error")
@@ -51,7 +53,18 @@ func NewMigrateCommand() *cobra.Command {
 					Msg("Moved latex image includes in own file")
 			}
 
-			migrated, err = migrate.InsertOrUpdateVersion(path+"/", "v2")
+			// v3
+			migrated, err = migrate.ReduceElevationProfileToLabels(path + "/")
+			if err != nil {
+				log.Fatal().Err(err).Str("filename", path).Msg("Migration error")
+			}
+
+			if migrated {
+				log.Info().Str("dirname", path).
+					Msg("Removed all gnuplot elevation data from actifity")
+			}
+
+			migrated, err = migrate.InsertOrUpdateVersion(path+"/", "v3")
 			if err != nil {
 				log.Fatal().Err(err).Str("filename", path).Msg("Migration error")
 			}

--- a/pkg/activity/activity.go
+++ b/pkg/activity/activity.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/nce/tourenbuchctl/pkg/migrate"
 	"github.com/nce/tourenbuchctl/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/text/language"
@@ -167,16 +166,6 @@ func (a *Activity) initSkeleton(file string) (string, error) {
 //
 //gocyclo:ignore
 func (a *Activity) updateActivity(dir string) error {
-	migrated, err := migrate.SplitDescriptionFile(a.Meta.TextLocation)
-	if err != nil {
-		return fmt.Errorf("migration error in %s: %w", a.Meta.TextLocation, err)
-	}
-
-	if migrated {
-		log.Info().Str("filename", a.Meta.TextLocation).
-			Msg("Description split into header.yaml and description.md")
-	}
-
 	file := dir + "header.yaml"
 
 	yamlFile, err := os.ReadFile(file)

--- a/pkg/activity/templates/mtb/header.yaml
+++ b/pkg/activity/templates/mtb/header.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: v2
+  version: v3
 activity:
   mtb: true
   type: mtb
@@ -25,6 +25,7 @@ stats:
 
 layout:
   headElevationProfile: false
+  elevationProfileType: left-axis-layout
   tableSize: 0.50
   mapSize: 0.49
   mapHeight: 17

--- a/pkg/activity/templates/skitour/elevation.plt
+++ b/pkg/activity/templates/skitour/elevation.plt
@@ -1,0 +1,5 @@
+# vim: set ft=gnuplot:
+
+set label 1 sprintf("\\textcolor\{skitour\}\{%s \\tiny %sm\}", ARG1, ARG2) at STATS_pos_max_y,STATS_max_y  point pointtype 7 ps 0.6 offset 0.3,0.3 front
+# set label 1 '\textcolor{skitour}{ \scriptsize m}' at STATS_pos_max_y,STATS_max_y point pointtype 7 ps 0.6 offset 0.3,0.3 front
+#set label 2 '\textcolor{skitour}{\tiny m}' at 3.2,1830 point pointtype 7 ps 0.6 offset -0.3,0.3 front rotate by 90

--- a/pkg/activity/templates/wandern/header.yaml
+++ b/pkg/activity/templates/wandern/header.yaml
@@ -1,5 +1,5 @@
 meta:
-  version: v2
+  version: v3
 activity:
   wandern: true
   type: wandern
@@ -26,8 +26,9 @@ stats:
 
 layout:
   headElevationProfile: false
+  elevationProfileType: left-axis-layout
+  elevationProfileRightMargin: 0
   tableSize: 0.45
   mapSize: 0.59
   mapHeight: 22
   linespread: 1.05
-  elevationProfileRightMargin: 0

--- a/pkg/migrate/splitelevation.go
+++ b/pkg/migrate/splitelevation.go
@@ -1,0 +1,78 @@
+package migrate
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nce/tourenbuchctl/pkg/activity"
+	"gopkg.in/yaml.v3"
+)
+
+func ReduceElevationProfileToLabels(textDir string) (bool, error) {
+	content, err := os.ReadFile("elevation.plt")
+	if err != nil {
+		return false, fmt.Errorf("error reading input file: %w", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+
+	var filteredLines []string
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "set label") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	//nolint: gosec
+	err = os.WriteFile(textDir+"elevation.plt", []byte(strings.Join(filteredLines, "\n")), 0o644)
+	if err != nil {
+		return false, fmt.Errorf("error writing to input file: %w", err)
+	}
+
+	_, err = insertElevationProfileType(textDir)
+	if err != nil {
+		return false, fmt.Errorf("error writing to input file: %w", err)
+	}
+
+	return true, nil
+}
+
+func insertElevationProfileType(textDir string) (bool, error) {
+	data, err := os.ReadFile(textDir + "header.yaml")
+	if err != nil {
+		return false, fmt.Errorf("error reading file: %w", err)
+	}
+
+	var header activity.Header
+
+	err = yaml.Unmarshal(data, &header)
+	if err != nil {
+		return false, fmt.Errorf("error unmarshalling YAML: %w", err)
+	}
+
+	// Check if elevationProfile key exists under layout
+	if header.Layout.ElevationProfileType == "" {
+		// If elevationProfile key does not exist, add it
+		header.Layout.ElevationProfileType = "left-axis-layout"
+	}
+	// Marshal the updated data back to YAML
+	var enc bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&enc)
+	yamlEncoder.SetIndent(2)
+
+	err = yamlEncoder.Encode(&header)
+	if err != nil {
+		return false, fmt.Errorf("error encoding YAML: %w", err)
+	}
+
+	//nolint: gosec
+	err = os.WriteFile(textDir+"header.yaml", enc.Bytes(), 0o644)
+	if err != nil {
+		return false, fmt.Errorf("error writing to file: %w", err)
+	}
+
+	return true, nil
+}

--- a/pkg/render/templates/elevationprofile/activity-settings.plt
+++ b/pkg/render/templates/elevationprofile/activity-settings.plt
@@ -1,0 +1,34 @@
+# vim: set ft=gnuplot:
+
+# -- [ Colors ] --
+# Wandern   ForestGreen #009B55
+# MTB       Maroon      #AF3235
+# Skitour   RoyalBlue   #006EB8
+# Alternat. Olivegreen  #3C8031
+wandernColor  = "#009B55"
+mtbColor      = "#AF3235"
+skitourColor  = "#006EB8"
+cycloColor    = "#F3BD2B"
+olivegreen    = "#3C8031"
+
+altcolor = olivegreen
+
+mtbTics = 200
+mtbKM   = 20
+mtbHM   = 0.235
+
+wandernTics = 100
+wandernKM   = 44.97   # 17.99cm / 40km
+wandernHM   = 0.255
+
+skitourTics = 200
+skitourKM   = 75.2
+skitourHM   = 0.376
+
+rennradTics = 200
+rennradKM   = 12.53
+rennradHM   = 0.313
+
+cycloTics = 100
+cycloKM   = 36.67
+cycloHM   = 0.48

--- a/pkg/render/templates/elevationprofile/left-axis-layout.plt
+++ b/pkg/render/templates/elevationprofile/left-axis-layout.plt
@@ -1,0 +1,62 @@
+# vim: set ft=gnuplot:
+
+# this creates the default layout with axis labels on the left and continuous
+# grid.
+# default for: mtb, hike, ...
+
+load "activity-settings.plt"
+
+myScaleKM = {{ .Activity }}KM
+myScaleHM = {{ .Activity }}HM
+myTics = {{ .Activity }}Tics
+myColor = {{ .Activity }}Color
+
+file = 'gpxdata.txt'
+
+reset
+unset key
+stats file u 3:2 nooutput
+set xrange [STATS_min_x:STATS_max_x]
+# floor to lowest elevation, to always display minimum elevation;
+set yrange [floor(STATS_min_y/myTics) * myTics:STATS_max_y]
+set y2range [floor(STATS_min_y/myTics) * myTics:STATS_max_y]
+
+# Max Km mit Skalierungsfaktor. Den (fiktiven) Pixelwert von 300dpi auf cm umrechnen und den gesamten Skalierungsfaktor darauf mulitiplizieren.
+# vielleicht nicht so ideal
+w = floor(STATS_max_x * myScaleKM) * 2.54 / 300 * 2
+# h = floor((STATS_max_y - STATS_min_y) * myScaleHM) * 2.54 / 300 * 2
+# switch from 300 to 250 as small tours are getting dense 07.2016
+h = floor((STATS_max_y - STATS_min_y) * myScaleHM) * 2.54 / 250 * 2
+
+# -- [ Labels ] --
+load "elevation.plt"
+
+# -- [ Terminal ] --
+# epslates does not support transparency
+# for mac xquartz is required to install epslatex https://xquartz.macosforge.org/landing/
+# brew install gnuplot --cairo
+set terminal cairolatex size w cm,h cm color
+set output "elevation.tex"
+
+# -- [ Grid and Tics ] --
+set xtic 5
+set xtic nomirror
+unset border
+set grid lt 0 dashtype 2 lw 3 lc rgb "black"
+set format x "%g\\tiny\\,\\color{darkgray}{km}"
+
+# left labeled axis
+set ytics border myTics nomirror
+set format y "%h\\tiny\\,\\color{darkgray}{m}"
+# cut right margin
+set rmargin at screen 1
+
+set border 3 lt 3 lw 3 lc rgb "#708090"
+
+# correct the margin calculations which are based
+# on the length of the format string, to a fixed value
+set lmargin 4.8
+
+set style fill transparent solid 0.45 noborder
+plot file u 3:2 w filledcurve x1 lc rgb "black" , \
+  file u 3:2 w lines lt 1 lw 5 lc rgb myColor

--- a/pkg/render/templates/elevationprofile/right-axis-filtered-layout.plt
+++ b/pkg/render/templates/elevationprofile/right-axis-filtered-layout.plt
@@ -1,0 +1,69 @@
+# vim: set ft=gnuplot:
+
+# this creates the filtered layout with axis labels on the right and a white
+# overlay for everything left of the peak
+# default for: skitour
+
+load "activity-settings.plt"
+
+myScaleKM = {{ .Activity }}KM
+myScaleHM = {{ .Activity }}HM
+myTics = {{ .Activity }}Tics
+myColor = {{ .Activity }}Color
+
+file = 'gpxdata.txt'
+
+reset
+unset key
+stats file u 3:2 nooutput
+set xrange [STATS_min_x:STATS_max_x]
+# floor to lowest elevation, to always display minimum elevation;
+set yrange [floor(STATS_min_y/myTics) * myTics:STATS_max_y]
+set y2range [floor(STATS_min_y/myTics) * myTics:STATS_max_y]
+
+# Max Km mit Skalierungsfaktor. Den (fiktiven) Pixelwert von 300dpi auf cm
+# umrechnen und den gesamten Skalierungsfaktor darauf mulitiplizieren.
+# vielleicht nicht so ideal
+w = floor(STATS_max_x * myScaleKM) * 2.54 / 300	* 2
+h = floor((STATS_max_y - STATS_min_y) * myScaleHM) * 2.54 / 300 * 2
+
+# -- [ Terminal ] --
+# epslates does not support transparency
+# for mac xquartz is required to install epslatex https://xquartz.macosforge.org/landing/
+# brew install gnuplot --cairo
+set terminal cairolatex size w cm,h cm color
+set output "elevation.tex"
+set multiplot
+
+# -- [ Grid and Tics ] --
+set xtics 5
+unset border
+unset xtics
+unset ytics
+unset x2tics
+set y2tics border myTics
+set format x "%g\\tiny\\,\\color{darkgray}{km}"
+set format y2 "%h\\tiny\\,\\color{darkgray}{m}"
+set border 8 lt 0 lw 3 lc rgb "black"
+#set ytic scale 0
+set xtics
+set grid y2 lt 0 lw 3 lc rgb "black"
+
+# huge change in scaling; but removes right margin
+set rmargin at screen 0.915;
+
+# only draw values until the highest point; this is used to overwrite the leftside grid
+filter(x,max) = (x <= max) ? x: 1/0
+
+set style fill transparent solid 0.45 noborder
+plot file u 3:2 w filledcurve x1 lc rgb "black" , \
+  file u 3:2 w lines lt 1 lw 5 lc rgb myColor
+unset grid
+set style fill solid noborder
+set noborder
+set nolabel
+
+# -- [ Labels ] --
+load "elevation.plt"
+
+plot file u (filter($3,STATS_pos_max_y)-0.01):($2 + 5) w filledcurve above x2 lc rgb "white"

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,10 @@
 package utils
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"testing"
+)
 
 func TestSplitDirectoryName(t *testing.T) {
 	t.Parallel()
@@ -28,4 +32,67 @@ func TestSplitDirectoryName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadActivityTypeFromHeader(t *testing.T) {
+	t.Parallel()
+
+	dirName := t.TempDir()
+	expected := "running"
+
+	// Create a test header.yaml file in the testdata directory
+	err := createTestHeaderFile(dirName, expected, "foo")
+	if err != nil {
+		t.Fatalf("error creating test file: %v", err)
+	}
+
+	// Test reading activity type from header.yaml
+	activityType, err := ReadActivityTypeFromHeader(dirName)
+	if err != nil {
+		t.Fatalf("error reading activity type: %v", err)
+	}
+
+	if activityType != expected {
+		t.Errorf("expected activity type %s, got %s", expected, activityType)
+	}
+}
+
+func TestReadElevationProfileTypeFromHeader(t *testing.T) {
+	t.Parallel()
+
+	dirName := t.TempDir()
+	expected := "left-axis"
+
+	// Create a test header.yaml file in the testdata directory
+	err := createTestHeaderFile(dirName, "foo", expected)
+	if err != nil {
+		t.Fatalf("error creating test file: %v", err)
+	}
+
+	// Test reading activity type from header.yaml
+	elevationProfileType, err := ReadElevationProfileTypeFromHeader(dirName)
+	if err != nil {
+		t.Fatalf("error reading elevationProfileType: %v", err)
+	}
+
+	if elevationProfileType != expected {
+		t.Errorf("expected layout elevationProfileType %s, got %s", expected, elevationProfileType)
+	}
+}
+
+func createTestHeaderFile(dirName, activityType string, elevationProfileType string) error {
+	headerContent := []byte(`
+activity:
+  type: ` + activityType + `
+layout:
+  elevationProfileType: ` + elevationProfileType + `
+`)
+
+	//nolint: gosec
+	err := os.WriteFile(dirName+"/header.yaml", headerContent, 0o644)
+	if err != nil {
+		return fmt.Errorf("error setting up header.yaml: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR removes the scattered and unupdatable gnuplot files. Master template is now included in the binary with config options through the `header.yaml`.

Currently mainly:
* `right-axis-filtered-layout`
* `left-axis-layout` (default)

Migration options are updated to reflect this change; Newly added config options result in new config version (`v3`)

Implements the gnuplot part of #1